### PR TITLE
Make the host path to the kublet directory reassignable

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: democratic-csi
-version: 0.4.3
+version: 0.4.4

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -98,7 +98,7 @@ spec:
         - name: socket-dir
           mountPath: /csi-data
         - name: mountpoint-dir
-          mountPath: /var/lib/kubelet
+          mountPath: {{ .Values.node.kubeletHostPath }}
           mountPropagation: Bidirectional
         - name: iscsi-dir
           mountPath: /etc/iscsi
@@ -134,7 +134,7 @@ spec:
         args:
         - --v=5
         - --csi-address=/csi-data/csi.sock
-        - --kubelet-registration-path=/var/lib/kubelet/plugins/{{ .Values.csiDriver.name }}/csi.sock
+        - --kubelet-registration-path={{ .Values.node.kubeletHostPath }}/plugins/{{ .Values.csiDriver.name }}/csi.sock
         env:
         - name: KUBE_NODE_NAME
           valueFrom:
@@ -171,19 +171,19 @@ spec:
       volumes:
       - name: socket-dir
         hostPath:
-          path: /var/lib/kubelet/plugins/{{ .Values.csiDriver.name }}
+          path: {{ .Values.node.kubeletHostPath }}/plugins/{{ .Values.csiDriver.name }}
           type: DirectoryOrCreate
       - name: plugins-dir
         hostPath:
-          path: /var/lib/kubelet/plugins
+          path: {{ .Values.node.kubeletHostPath }}/plugins
           type: Directory
       - name: registration-dir
         hostPath:
-          path: /var/lib/kubelet/plugins_registry
+          path: {{ .Values.node.kubeletHostPath }}/plugins_registry
           type: Directory
       - name: mountpoint-dir
         hostPath:
-          path: /var/lib/kubelet
+          path: {{ .Values.node.kubeletHostPath }}
           type: Directory
       - name: iscsi-dir
         hostPath:

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -100,6 +100,7 @@ node:
   enabled: true
   hostNetwork: true
   hostIPC: true
+  kubeletHostPath: /var/lib/kubelet
 
   livenessProbe:
     enabled: true


### PR DESCRIPTION
Some kubernetes distributions do not use the traditional kubernetes
directory locations. For example, minikube relocates /var/lib/kubelet to
/var/snap/microk8s/common/var/lib/kubelet, so make a variable in
values.yaml to redefine the host path to the /var/lib/kublet
directory.