### PR TITLE
Allow overwriting localtime host path mount

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: democratic-csi
-version: 0.4.5
+version: 0.4.6

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -112,9 +112,11 @@ spec:
         - name: modules-dir
           mountPath: /lib/modules
           readOnly: true
+        {{- if .Values.node.driver.localtimeHostPath }}
         - name: localtime
           mountPath: /etc/localtime
           readOnly: true
+        {{- end }}
         - name: udev-data
           mountPath: /run/udev
         - name: host-dir
@@ -204,9 +206,11 @@ spec:
       - name: modules-dir
         hostPath:
           path: /lib/modules
+      {{- if .Values.node.driver.localtimeHostPath }}
       - name: localtime
         hostPath:
-          path: /etc/localtime
+          path: {{ .Values.node.driver.localtimeHostPath }}
+      {{- end }}
       - name: udev-data
         hostPath:
           path: /run/udev

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -110,6 +110,8 @@ node:
     enabled: true
     image: democraticcsi/democratic-csi:latest
     logLevel: info
+    # set path to null if your OS has no localtime file (e.g. for RancherOS)
+    localtimeHostPath: /etc/localtime
     lifecycle:
 #      postStart:
 #        exec:


### PR DESCRIPTION
Some operating systems like RancherOS don't have a localtime file, so the container fails because Docker creates a directory at `/etc/localtime` and tries to mount it on top of the localtime file inside the container.