### PR TITLE
Fixup: Remove deprecated `.Capabilities.KubeVersion.GitVersion`

### DIFF
--- a/stable/democratic-csi/templates/csidrivercrd.yaml
+++ b/stable/democratic-csi/templates/csidrivercrd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.csiDriver.installCRD -}}
 ---
-{{- if semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: apiextensions.k8s.io/v1
 {{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/stable/democratic-csi/templates/driver.yaml
+++ b/stable/democratic-csi/templates/driver.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.csiDriver.enabled -}}
 ---
-{{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version }}
 apiVersion: storage.k8s.io/v1
 {{- else }}
 apiVersion: storage.k8s.io/v1beta1
@@ -16,7 +16,7 @@ metadata:
 spec:
   attachRequired: {{ .Values.csiDriver.attachRequired }}
   podInfoOnMount: {{ .Values.csiDriver.podInfoOnMount }}
-  {{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version }}
   {{- if .Values.csiDriver.fsGroupPolicy }}
   fsGroupPolicy: {{ .Values.csiDriver.fsGroupPolicy }}
   {{- end }}
@@ -25,27 +25,27 @@ spec:
   #  volumeLifecycleModes:
   #  - Persistent
   #  - Ephemeral
-  {{- if semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.Version }}
   {{- if .Values.csiDriver.volumeLifecycleModes }}
   volumeLifecycleModes:
 {{ toYaml .Values.csiDriver.volumeLifecycleModes | indent 2 }}
   {{- end }}
   {{- end }}
 
-  {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
   {{- if .Values.csiDriver.tokenRequests }}
   tokenRequests:
 {{ toYaml .Values.csiDriver.tokenRequests | indent 2 }}
   {{- end }}
   {{- end }}
 
-  {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
   {{- if or (eq ( .Values.csiDriver.requiresRepublish | toString ) "false") (eq ( .Values.csiDriver.requiresRepublish | toString ) "true") }}
   requiresRepublish: {{ .Values.csiDriver.requiresRepublish }}
   {{- end }}
   {{- end }}
 
-  {{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version }}
   {{- if or (eq ( .Values.csiDriver.storageCapacity | toString ) "false") (eq ( .Values.csiDriver.storageCapacity | toString ) "true") }}
   storageCapacity: {{ .Values.csiDriver.storageCapacity }}
   {{- end }}

--- a/stable/democratic-csi/templates/snapshot-classes.yaml
+++ b/stable/democratic-csi/templates/snapshot-classes.yaml
@@ -4,9 +4,9 @@
 {{- range .Values.volumeSnapshotClasses }}
 {{- $classRoot := . -}}
 ---
-{{- if semverCompare ">=1.20.0-0" $root.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.20.0-0" $root.Capabilities.KubeVersion.Version }}
 apiVersion: snapshot.storage.k8s.io/v1
-{{- else if semverCompare ">=1.17.0-0" $root.Capabilities.KubeVersion.GitVersion }}
+{{- else if semverCompare ">=1.17.0-0" $root.Capabilities.KubeVersion.Version }}
 apiVersion: snapshot.storage.k8s.io/v1beta1
 {{- else }}
 apiVersion: snapshot.storage.k8s.io/v1alpha1
@@ -26,7 +26,7 @@ metadata:
     helm.sh/chart: {{ include "democratic-csi.chart" $root }}
     app.kubernetes.io/instance: {{ $root.Release.Name }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service }}
-{{- if semverCompare ">=1.17.0-0" $root.Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.17.0-0" $root.Capabilities.KubeVersion.Version }}
 driver: {{ $root.Values.csiDriver.name }}
 deletionPolicy: {{ $classRoot.deletionPolicy | default "Delete" }}
 {{- else }}


### PR DESCRIPTION
The Helm docs don't publish this value anymore: https://helm.sh/docs/chart_template_guide/builtin_objects/

Seems it was removed ~3 years ago in https://github.com/helm/helm/commit/097834de0ad7e33fc5f13088fbb5a17128fb21e3

The Helm source states to use `.Capabilities.KubeVersion.Version` instead: https://github.com/helm/helm/blob/a499b4b179307c267bdf3ec49b880e3dbd2a5591/pkg/chartutil/capabilities.go#L71-L74