### PR TITLE
chart: allow to deploy in a given namespace.

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.10.1
+version: 0.10.2

--- a/stable/democratic-csi/templates/configmap.yaml
+++ b/stable/democratic-csi/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "democratic-csi.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/controller-rbac.yaml
+++ b/stable/democratic-csi/templates/controller-rbac.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-controller-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/controller.yaml
+++ b/stable/democratic-csi/templates/controller.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/driver-config-secret.yaml
+++ b/stable/democratic-csi/templates/driver-config-secret.yaml
@@ -5,6 +5,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-driver-config
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/node-rbac.yaml
+++ b/stable/democratic-csi/templates/node-rbac.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-node-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -7,6 +7,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}

--- a/stable/democratic-csi/templates/snapshot-classes.yaml
+++ b/stable/democratic-csi/templates/snapshot-classes.yaml
@@ -56,6 +56,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-%s-%s" $k $classRoot.name $fullName | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $root.Release.Namespace }}
 type: Opaque
 stringData:
 {{- range $k, $v := $v }}

--- a/stable/democratic-csi/templates/storage-classes.yaml
+++ b/stable/democratic-csi/templates/storage-classes.yaml
@@ -60,6 +60,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-%s-%s" $k $classRoot.name $fullName | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $root.Release.Namespace }}
 type: Opaque
 stringData:
 {{- range $k, $v := $v }}


### PR DESCRIPTION
When not using helm directly but rather rely on a external tool to
deploy the app (i.e kapp), the rendered templates does not include
namespace information in the needed resources. Hence, the application
is deployed in the default namespace.

This is annoying because we have to rely on additionnal CLI flag to
setup the app in the correct namespace.

Now, this is working fine if we apply the rendered template using an
external tool without any extra namesapce argument needed:

```
storage          democratic-csi-controller-b685786c8-n2qmq   4/4     Running   0          8m27s
storage          democratic-csi-node-74b8p                   3/3     Running   0          8m27s
storage          democratic-csi-node-fmg56                   3/3     Running   0          8m27s
storage          democratic-csi-node-gfthq                   3/3     Running   0          8m27s
storage          democratic-csi-node-h8d4h                   3/3     Running   0          8m27s
storage          democratic-csi-node-m5ztw                   3/3     Running   0          8m27s
storage          democratic-csi-node-tx5np                   3/3     Running   0          8m27s
storage          democratic-csi-node-vdz2v                   3/3     Running   0          8m27s
```

Signed-off-by: Lionel H <me@nullbyte.be>