### PR TITLE
iSCSI mount breaks on Fedora CoreOS worker nodes

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.10.3
+version: 0.10.4

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -193,7 +193,7 @@ spec:
           - "-c"
           - "--"
         args: [ "while true; do sleep 2; done;" ]
-  
+
         lifecycle:
           # note this runs *before* other containers are terminated
           preStop:
@@ -228,7 +228,6 @@ spec:
       - name: iscsi-dir
         hostPath:
           path: /etc/iscsi
-          type: Directory
       - name: iscsi-info
         hostPath:
           path: /var/lib/iscsi
@@ -285,4 +284,3 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
-


### PR DESCRIPTION
> tl;dr A config value that is not needed for most use-cases causes hard to troubleshoot failures in some situations.

The existing mount spec defines the `/etc/iscsi` mount as `type: Directory`. This results in a check of `/etc/iscsi` to determine if it exists and is a directory. On Fedora CoreOS the directory type check tells the runtime that the path is not a directory despite it appearing as a directory via `ls -la`.

For the life of me, I couldn't figure out why this is happening. I think it may be related to the OS' usage of OSTree but I am unsure.

Here is the `kubelet` log:
```
Mar 03 05:05:12 blade-kube-04.plato.local conmon[3172]: E0303 05:05:12.193308    3175 nestedpendingoperations.go:335] Operation for "{volumeName:kubernetes.io/host-path/e8bc0f85-5952-48d0-9c8b-33fd7574e707-iscsi-dir podName:e8bc0f85-5952-48d0-9c8b-33fd7574e707 nodeName:}" failed. No retries permitted until 2022-03-03 05:07:14.193272754 +0000 UTC m=+155943.871215963 (durationBeforeRetry 2m2s).

Error: MountVolume.SetUp failed for volume "iscsi-dir" (UniqueName: "kubernetes.io/host-path/e8bc0f85-5952-48d0-9c8b-33fd7574e707-iscsi-dir") pod "zfs-api-iscsi-democratic-csi-node-gl4zc" (UID: "e8bc0f85-5952-48d0-9c8b-33fd7574e707") : hostPath type check failed: /etc/iscsi is not a directory
```

Since this directory needs to exist for the node workers to use iSCSI I think it's safe to remove this part of the spec for normal deployments. If a node is not configured with iSCSI and that directory is empty or non-existent the error in the logs will now be slightly more actionable than it was for me.

I've banged my head against this for several evenings this week and the only hints I found online were related to removing this from the spec. As soon as I did everything worked great on all 5 of my worker nodes. (I am running on bare-metal.)