### PR TITLE
Parameterized the cleanup image

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.10.3
+version: 0.10.4

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -187,7 +187,7 @@ spec:
           mountPath: /registration
 
       - name: cleanup
-        image: docker.io/busybox:1.32.0
+        image: {{ .Values.node.cleanup.image }}
         command:
           - "/bin/sh"
           - "-c"

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -212,6 +212,9 @@ node:
   livenessProbe:
     enabled: true
 
+  cleanup:
+    image: docker.io/busybox:1.32.0
+
   # democratic-csi node
   driver:
     enabled: true


### PR DESCRIPTION
I need to be able to replace image references to docker.io with a mirrored repository and ran into an error with this new "cleanup" image.  
