### PR TITLE
Add csi-role to matchLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# 0.10.5
+# 0.12.0
+- include `app.kubernetes.io/csi-role` in matchLabels on Deployment and DaemonSet
+  - requires `helm uninstall` and `helm install` to upgrade from older versions
+
+# 0.11.2
+  - bump `csi-grpc-proxy` for multiarch support and memory fixes
+
+# 0.10.11
 
 - csiProxy support
 - bump `node-driver-registrar`

--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.11.2
+version: 0.12.0

--- a/stable/democratic-csi/templates/controller.yaml
+++ b/stable/democratic-csi/templates/controller.yaml
@@ -18,6 +18,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/csi-role: "controller"
   template:
     metadata:
       annotations:

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -19,6 +19,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/csi-role: "node"
   template:
     metadata:
       annotations:
@@ -216,7 +217,7 @@ spec:
           - "-c"
           - "--"
         args: [ "while true; do sleep 2; done;" ]
-  
+
         lifecycle:
           # note this runs *before* other containers are terminated
           preStop:


### PR DESCRIPTION
The `matchLabels` attributes were identical between the DaemonSet and the Deployment, causing all the pods from both to show when using a tool like [k9s](https://k9scli.io/) or the [web dashboard](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/).

## Upgrade gotcha
This adds the `app.kubernetes.io/csi-role` label to the `matchLabels`, but this does not work with `helm upgrade` because a `PATCH` on these attributes is not supported. A `helm uninstall`, followed by `helm install` is necessary to perform the migration.