### PR TITLE
Adding PSP template and values

### DIFF
--- a/stable/democratic-csi/templates/psp.yaml
+++ b/stable/democratic-csi/templates/psp.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.enablePSP }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "democratic-csi.fullname" . }}-psp
+    app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
+    helm.sh/chart: {{ include "democratic-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+  - NET_RAW
+  allowedCapabilities:
+  - SYS_ADMIN
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - secret
+  - projected
+  - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "democratic-csi.fullname" . }}-role
+    app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
+    helm.sh/chart: {{ include "democratic-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ include "democratic-csi.fullname" . }}-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "democratic-csi.fullname" . }}-psp-binding
+    app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
+    helm.sh/chart: {{ include "democratic-csi.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "democratic-csi.fullname" . }}-psp-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "democratic-csi.fullname" . }}-controller-sa
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ include "democratic-csi.fullname" . }}-node-sa
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -309,3 +309,6 @@ volumeSnapshotClasses: []
 csiProxy:
   enabled: true
   image: docker.io/democraticcsi/csi-grpc-proxy:v0.4.2
+
+# Configure a pod security policy to allow privileged pods
+enablePSP: false


### PR DESCRIPTION
This PR is part of https://github.com/democratic-csi/democratic-csi/issues/188

In this PR I'm adding a PSP for the controller and nodes pods. (I used Longhorn's PSP and chart as a framework [here](https://github.com/longhorn/longhorn/blob/master/chart/templates/psp.yaml).

Note: I'm leaving the default behavior the same with it being setting the values.yaml to `enablePSP: false` IE Helm will not create the PSP, role, and rolebindings unless a user enables it.