### PR TITLE
Add configurable priorityClassName to node and controller workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.13.5
+
+Released 2022-09-20
+
+- add `priorityClassName` value for both node DaemonSet and controller Deployment
+
 # 0.13.4
 
 Released 2022-08-07

--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.13.4
+version: 0.13.5

--- a/stable/democratic-csi/templates/controller.yaml
+++ b/stable/democratic-csi/templates/controller.yaml
@@ -47,6 +47,9 @@ spec:
       {{- if .Values.controller.rbac.enabled }}
       serviceAccount: {{ include "democratic-csi.fullname" . }}-controller-sa
       {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+      {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
       hostAliases: {{ .Values.controller.hostAliases }}
       hostIPC: {{ .Values.controller.hostIPC }}

--- a/stable/democratic-csi/templates/node-windows.yaml
+++ b/stable/democratic-csi/templates/node-windows.yaml
@@ -49,6 +49,9 @@ spec:
       {{- if .Values.node.rbac.enabled }}
       serviceAccount: {{ include "democratic-csi.fullname" . }}-node-sa
       {{- end }}
+      {{- if .Values.node.priorityClassName }}
+      priorityClassName: "{{ .Values.node.priorityClassName }}"
+      {{- end }}
       hostNetwork: {{ .Values.node.hostNetwork }}
       hostAliases: {{ .Values.node.hostAliases }}
       securityContext:

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -47,6 +47,9 @@ spec:
       {{- if .Values.node.rbac.enabled }}
       serviceAccount: {{ include "democratic-csi.fullname" . }}-node-sa
       {{- end }}
+      {{- if .Values.node.priorityClassName }}
+      priorityClassName: "{{ .Values.node.priorityClassName }}"
+      {{- end }}
       # Required by iSCSI
       hostNetwork: {{ .Values.node.hostNetwork }}
       hostAliases: {{ .Values.node.hostAliases }}

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -65,6 +65,7 @@ controller:
   hostIPC: false
   podAnnotations: {}
   podLabels: {}
+  priorityClassName: ""
   
   # deployment = deploy controller parts in a distinct deployment
   # node       = deploy controller as sidecars with node daemonset
@@ -214,6 +215,7 @@ node:
   kubeletHostPath: /var/lib/kubelet
   podAnnotations: {}
   podLabels: {}
+  priorityClassName: ""
 
   livenessProbe:
     enabled: true


### PR DESCRIPTION
Allow specifying optional `priorityClassName` for node DaemonSet and controller Deployment pod specs.

Implements #35.