### PR TITLE
Improve version handling

### DIFF
--- a/stable/snapshot-controller/templates/setup-snapshot-controller.yaml
+++ b/stable/snapshot-controller/templates/setup-snapshot-controller.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: snapshot-controller
-          image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+          image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default (printf "v%s" .Chart.AppVersion) }}
           {{- if .Values.controller.image.pullPolicy }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           {{- end }}
@@ -62,3 +62,4 @@ spec:
           - {{ tpl . $root }}
           {{- end }}
 {{- end }}
+

--- a/stable/snapshot-controller/templates/webhook.yaml
+++ b/stable/snapshot-controller/templates/webhook.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: snapshot-validation
-        image: {{ .Values.validatingWebhook.image.repository }}:{{ .Values.validatingWebhook.image.tag }}
+        image: {{ .Values.validatingWebhook.image.repository }}:{{ .Values.validatingWebhook.image.tag  | default (printf "v%s" .Chart.AppVersion) }}
         {{- if .Values.validatingWebhook.image.pullPolicy }}
         imagePullPolicy: {{ .Values.validatingWebhook.image.pullPolicy }}
         {{- end }}

--- a/stable/snapshot-controller/values.yaml
+++ b/stable/snapshot-controller/values.yaml
@@ -18,7 +18,7 @@ controller:
     repository: registry.k8s.io/sig-storage/snapshot-controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v6.0.1
+    tag: ""
 
   args:
   - "--v=5"
@@ -35,5 +35,5 @@ validatingWebhook:
     repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v6.0.1
+    tag: ""
 


### PR DESCRIPTION
Add support for snapshot controller to use the `Chart.yaml` variable  `appVersion` for image tag
if tag is empty.
As expected on the comments of `values.yaml`
```
# Overrides the image tag whose default is the chart appVersion.
```