### PR TITLE
templates: fix PodSecurityPolicy missing label key

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.13.6
+version: 0.13.7

--- a/stable/democratic-csi/templates/psp.yaml
+++ b/stable/democratic-csi/templates/psp.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "democratic-csi.fullname" . }}-psp
+  labels:
     app.kubernetes.io/name: {{ include "democratic-csi.name" . }}
     helm.sh/chart: {{ include "democratic-csi.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
labels key were missing resulting in an error while trying to deploy the chart with PSP enabled:

```
Helm upgrade failed: YAML parse error on democratic-csi/templates/psp.yaml:
error converting YAML to JSON: yaml: line 5: mapping values are not allowed in this context...
```