### PR TITLE
Fix node-manual example no attach required

### DIFF
--- a/stable/democratic-csi/examples/node-manual.yaml
+++ b/stable/democratic-csi/examples/node-manual.yaml
@@ -2,6 +2,7 @@
 csiDriver:
   # should be globally unique for a given cluster
   name: "org.democratic-csi.node-manual"
+  attachRequired: false
 
 controller:
   enabled: false


### PR DESCRIPTION
Example leads to `AttachVolume.Attach failed for volume "[...]" : timed out waiting for external-attacher of democratic-csi.node-manual CS ││ I driver to attach volume [...]` without an attacher.