### PR TITLE
Make sure annotations is only outputted when there are some

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.14.3
+version: 0.14.4

--- a/stable/democratic-csi/templates/storage-classes.yaml
+++ b/stable/democratic-csi/templates/storage-classes.yaml
@@ -3,18 +3,19 @@
 {{- if .Values.storageClasses -}}
 {{- range .Values.storageClasses }}
 {{- $classRoot := . -}}
+{{- $storageClassAnnotations := ( $classRoot.annotations | default dict ) }}
+{{- if $classRoot.defaultClass }}
+{{- $storageClassAnnotations = merge $storageClassAnnotations (dict "storageclass.kubernetes.io/is-default-class" $classRoot.defaultClass) }}
+{{- end }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ required "storage class name is required" $classRoot.name }}
+  {{- with $storageClassAnnotations }}
   annotations:
-    {{- with $classRoot.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if $classRoot.defaultClass }}
-    storageclass.kubernetes.io/is-default-class: {{ $classRoot.defaultClass | quote }}
-    {{- end }}
+  {{- end }}
   labels:
     {{- with $classRoot.labels }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
In argocd, it compares the output from helm with the server version, and gets caught up on helm outputting `annotations:` but kube returning `annotations: null`

This just prevents annotation from being rendered unless there are annotations.