### PR TITLE
adding resources

### DIFF
--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -243,6 +243,11 @@ spec:
           - "-c"
           - "--"
         args: [ "while true; do sleep 2; done;" ]
+        {{- if .Values.node.driver.resources }}
+        resources:
+{{ toYaml .Values.node.cleanup.resources | indent 10 }}
+        {{- end }}
+
 
         lifecycle:
           # note this runs *before* other containers are terminated

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -226,6 +226,7 @@ node:
 
   cleanup:
     image: docker.io/busybox:1.32.0
+    resources:
 
   # democratic-csi node
   driver:


### PR DESCRIPTION
There's now no way to add resources to "cleanup" container which is being a part of daemonset deployed on all nodes
That PR is something that hasn't been tested as I don't have resources to create separate cluster to test it.
But looking how are other containers handled it should do the trick.
I hope some CI test will catch issues in case it's completely broken.