### PR TITLE
Add ability to configure `dnsPolicy`

### DIFF
--- a/stable/democratic-csi/templates/controller.yaml
+++ b/stable/democratic-csi/templates/controller.yaml
@@ -58,6 +58,7 @@ spec:
       priorityClassName: "{{ .Values.controller.priorityClassName }}"
       {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
       hostAliases: {{ .Values.controller.hostAliases }}
       hostIPC: {{ .Values.controller.hostIPC }}
       containers:

--- a/stable/democratic-csi/templates/node-windows.yaml
+++ b/stable/democratic-csi/templates/node-windows.yaml
@@ -60,6 +60,7 @@ spec:
       priorityClassName: "{{ .Values.node.priorityClassName }}"
       {{- end }}
       hostNetwork: {{ .Values.node.hostNetwork }}
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
       hostAliases: {{ .Values.node.hostAliases }}
       securityContext:
         windowsOptions:

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -59,6 +59,7 @@ spec:
       {{- end }}
       # Required by iSCSI
       hostNetwork: {{ .Values.node.hostNetwork }}
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
       hostAliases: {{ .Values.node.hostAliases }}
       # Required by multipath detach
       hostIPC: {{ .Values.node.hostIPC }}

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -67,6 +67,7 @@ controller:
       privileged: false
   replicaCount: 1
   hostNetwork: false
+  dnsPolicy: ClusterFirst
   hostAliases: []
   hostIPC: false
   annotations: {}
@@ -217,6 +218,7 @@ node:
       privileged: false
   enabled: true
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   hostAliases: []
   hostIPC: true
   hostPID: false


### PR DESCRIPTION
According to Kubernetes' [documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) the `dnsPolicy` should be set to `ClusterFirstWithHostNet` when `hostNetwork: true` is set. This PR adds the option to configure `dnsPolicy` for both `node` and `controller` parts of the Helm chart.

This solves an issue I was facing where a host was resolved by the controller (and so the NFS mount was configured) but was not resolved when the volume was mounted.

This is what `csi-driver-nfs` does: https://github.com/kubernetes-csi/csi-driver-nfs/blob/096163569b792c4eb38fcf652e8ef2c3a8a5060b/charts/v4.9.0/csi-driver-nfs/values.yaml#L102