### PR TITLE
Permit use of Secrets instead of inline text for iSCSI authentication

### DIFF
--- a/stable/democratic-csi/examples/freenas-nfs.yaml
+++ b/stable/democratic-csi/examples/freenas-nfs.yaml
@@ -26,12 +26,31 @@ storageClasses:
     mountOptions:
       - noatime
       - nfsvers=3
-    secrets:
-      provisioner-secret:
-      controller-publish-secret:
-      node-stage-secret:
-      node-publish-secret:
-      controller-expand-secret:
+
+    # existingSecrets will look for an existing secret with name/namespace and use the values within for authentication
+    # the existing secret should contain something similar to with proper references for your secret:
+    #   target:
+    #     name: existingSecretName
+    #     template:
+    #       engineVersion: v2
+    #       data:
+    #          node-db.node.session.auth.authmethod: "CHAP"
+    #          node-db.node.session.auth.username: "{{ .iscsi_username }}"
+    #          node-db.node.session.auth.password: "{{ .iscsi_password }}"
+    #          node-db.node.session.auth.username_in: "{{ .iscsi_username_in }}"
+    #          node-db.node.session.auth.password_in: "{{ .iscsi_password_in }}"
+    existingSecret:
+      nfs-chap-secret:
+        name: existingSecretName
+        namespace: existingSecretNameSpace
+
+    # you can use EITHER an existingSecret or inline secrets below--not both.
+    # secrets:
+    #   provisioner-secret:
+    #   controller-publish-secret:
+    #   node-stage-secret:
+    #   node-publish-secret:
+    #   controller-expand-secret:
 
 # if your cluster supports snapshots you may enable below
 volumeSnapshotClasses: []

--- a/stable/democratic-csi/examples/freenas-nfs.yaml
+++ b/stable/democratic-csi/examples/freenas-nfs.yaml
@@ -40,7 +40,7 @@ storageClasses:
     #          node-db.node.session.auth.username_in: "{{ .iscsi_username_in }}"
     #          node-db.node.session.auth.password_in: "{{ .iscsi_password_in }}"
     existingSecret:
-      nfs-chap-secret:
+      node-stage-secret: # this should be your chap secret
         name: existingSecretName
         namespace: existingSecretNameSpace
 

--- a/stable/democratic-csi/templates/storage-classes.yaml
+++ b/stable/democratic-csi/templates/storage-classes.yaml
@@ -38,10 +38,18 @@ parameters:
   {{ $k }}: {{ $v | quote }}
 {{- end }}
 
-# this loop is deeply connected to the loop for Secret creation below
+{{- if $classRoot.existingSecrets }}
+# all or nothing for secrets -> either the chart manages your secret or you need to manually do so
+{{- range $k, $v := $classRoot.existingSecrets }}
+  csi.storage.k8s.io/{{ $k }}-name: {{ $v.name }}
+  csi.storage.k8s.io/{{ $k }}-namespace: {{ default $root.Release.Namespace $v.namespace }}
+{{- end }}
+{{- else }}
+# if no existingSecrets, this loop (and the Secret creation below) will create them
 {{- range $k, $v := $classRoot.secrets }}
   csi.storage.k8s.io/{{ $k }}-name: {{ printf "%s-%s-%s" $k $classRoot.name $fullName | trunc 63 | trimSuffix "-" }}
   csi.storage.k8s.io/{{ $k }}-namespace: {{ $root.Release.Namespace }}
+{{- end }}
 {{- end }}
 
 {{- if $classRoot.mountOptions }}
@@ -51,10 +59,13 @@ mountOptions:
 {{ end }}
 {{- end }}
 
-# this loop is deeply connected to the loop for secret parameter settings above
+# if any storageClasses, look for existingSecrets (and do nothing) or secrets (and create them)
+# exclusive operation -> if existingSecrets found, you must manually create properly formatted secrets.
 {{- if .Values.storageClasses -}}
 {{- range .Values.storageClasses }}
 {{- $classRoot := . -}}
+# if you have an existingSecret, we're not creating _any_ secrets for you
+{{- if not $classRoot.existingSecrets }}
 {{- range $k, $v := $classRoot.secrets }}
 ---
 apiVersion: v1
@@ -66,6 +77,7 @@ type: Opaque
 stringData:
 {{- range $k, $v := $v }}
   {{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -299,6 +299,26 @@ storageClasses: []
 #    # for nfs should be nfs
 #    fsType:
 #  mountOptions: []
+
+#  existingSecrets:
+#    anyName:  # can be any arbitrary name
+#      name: existingSecretName
+#     namespace: existingSecretNamespace
+
+# existingSecrets will look for an existing secret with name/namespace and use the values within for authentication
+# the existing secret should contain something similar to with proper references for your secret:
+#   target:
+#     name: existingSecretName
+#     template:
+#       engineVersion: v2
+#       data:
+#          node-db.node.session.auth.authmethod: "CHAP"
+#          node-db.node.session.auth.username: "{{ .iscsi_username }}"
+#          node-db.node.session.auth.password: "{{ .iscsi_password }}"
+#          node-db.node.session.auth.username_in: "{{ .iscsi_username_in }}"
+#          node-db.node.session.auth.password_in: "{{ .iscsi_password_in }}"
+# if you use an existingSecret -- any `secrets` below WILL BE IGNORED.
+
 #  secrets:
 #    provisioner-secret:
 #    controller-publish-secret:


### PR DESCRIPTION
This patch creates a new key under storageClasses for `existingSecret` where for each of the `secrets` can be provided directly (name and namepace) instead of managed by the chart. E.g.:
```
storageClasses:
	- name: iscsi-delete
		defaultClass: true
		reclaimPolicy: Delete
		volumeBindingMode: WaitForFirstConsumer
    allowVolumeExpansion: true
    parameters:
      fstype: ext4
    existingSecrets:
    	node-stage-secret:
    		name: node-stage-secret-dcsi-iscsi-delete
    		namespace: storage
 ```

 The secret must be contain validly formatted keys. E.g.:

 ```
apiVersion: v1
kind: Secret
metadata:
  name: node-stage-secret-dcsi-iscsi-delete
  # namespace: storage
type: Opaque
stringData:
  node-db.node.session.auth.authmethod: "CHAP"
  node-db.node.session.auth.username: "<ISCSI_USERNAME>"
  node-db.node.session.auth.password: "<ISCSI_PASSWORD>"
  node-db.node.session.auth.username_in: "<ISCSI_USERNAME_IN>"
  node-db.node.session.auth.password_in: "<ISCSI_PASSWORD_IN>"
```

I chose to implement this as "all or nothing" regarding secrets management, with the belief that if someone is already in the weeds for one of the secrets, they would likely manually define all. So if the `existingSecrets` value exists (for a specific StorageClass), you must define all of the secrets that are necessary for that class. (Though some StorageClasses might use `existingSecrets` and others could use `secrets`--though I don't know why anyone would do that.)

I made this patch as I wasn't able to get any sort of secret injection to properly work on the existing implementation, and found several people referencing that they just encrypt the plain-text credentials in place. That seemed inelegant to me, given there is an entire secrets ecosystem in k8s (and I prefer to use ExternalSecrets to manage as much as possible.)

I'd be happy to write an update to the values file to reflect these changes if you find this PR suitable for inclusion.