### PR TITLE
ci: push Helm Chart to GHCR

### DIFF
--- a/.github/workflows/build_helm_repo.yaml
+++ b/.github/workflows/build_helm_repo.yaml
@@ -8,8 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -19,14 +22,31 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
+        uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.7.0
+        id: cr
         with:
           charts_dir: stable
         env:
-          CR_TOKEN: "${{ secrets.ACCESS_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
+
+      - if: ${{ steps.cr.outputs.changed_charts }}
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ steps.cr.outputs.changed_charts }}
+        name: Push Charts to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
+          done


### PR DESCRIPTION
>[!IMPORTANT]
> After this is merged and charts are released you will need to make the packages public from [here](https://github.com/orgs/democratic-csi/packages)

I also bumped some deps and replaced ACCESS_TOKEN secret with the builtin GITHUB_TOKEN

Fixes: https://github.com/democratic-csi/charts/issues/65

