### PR TITLE
Allow control of the verbosity level of binaries run by the chart

### DIFF
--- a/stable/democratic-csi/values.yaml
+++ b/stable/democratic-csi/values.yaml
@@ -87,7 +87,7 @@ controller:
       registry: registry.k8s.io/sig-storage/csi-attacher
       tag: v4.4.0
     args:
-      - --v=5
+      - --v={{ .Values.controller.externalAttacher.verbosityLevel }}
       - --leader-election
       - --leader-election-namespace={{ .Release.Namespace }}
       - --timeout=90s
@@ -96,6 +96,7 @@ controller:
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   # https://kubernetes-csi.github.io/docs/external-provisioner.html
   externalProvisioner:
@@ -104,7 +105,7 @@ controller:
       registry: registry.k8s.io/sig-storage/csi-provisioner
       tag: v3.6.0
     args:
-      - --v=5
+      - --v={{ .Values.controller.externalProvisioner.verbosityLevel }}
       - --leader-election
       - --leader-election-namespace={{ .Release.Namespace }}
       - --timeout=90s
@@ -114,6 +115,7 @@ controller:
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   # https://kubernetes-csi.github.io/docs/external-resizer.html
   externalResizer:
@@ -122,7 +124,7 @@ controller:
       registry: registry.k8s.io/sig-storage/csi-resizer
       tag: v1.9.0
     args:
-      - --v=5
+      - --v={{ .Values.controller.externalResizer.verbosityLevel }}
       - --leader-election
       - --leader-election-namespace={{ .Release.Namespace }}
       - --timeout=90s
@@ -131,6 +133,7 @@ controller:
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   # https://kubernetes-csi.github.io/docs/external-snapshotter.html
   externalSnapshotter:
@@ -141,7 +144,7 @@ controller:
       registry: registry.k8s.io/sig-storage/csi-snapshotter
       tag: v8.2.1
     args:
-      - --v=5
+      - --v={{ .Values.controller.externalSnapshotter.verbosityLevel }}
       - --leader-election
       - --leader-election-namespace={{ .Release.Namespace }}
       - --timeout=90s
@@ -150,6 +153,7 @@ controller:
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   # https://github.com/kubernetes-csi/external-health-monitor
   externalHealthMonitorController:
@@ -158,7 +162,7 @@ controller:
       registry: registry.k8s.io/sig-storage/csi-external-health-monitor-controller
       tag: v0.14.0
     args:
-      - --v=5
+      - --v={{ .Values.controller.externalHealthMonitorController.verbosityLevel }}
       - --leader-election
       - --leader-election-namespace={{ .Release.Namespace }}
       - --timeout=90s
@@ -169,6 +173,7 @@ controller:
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   # https://kubernetes-csi.github.io/docs/cluster-driver-registrar.html
   # not implemented, likely uncessary at this point
@@ -290,12 +295,13 @@ node:
       registry: registry.k8s.io/sig-storage/csi-node-driver-registrar
       tag: v2.9.0
     args:
-      - --v=5
+      - --v={{ .Values.node.driverRegistrar.verbosityLevel }}
       - --csi-address={{ .csiSocketAddress }}
       - --kubelet-registration-path={{ .Values.node.kubeletHostPath }}/plugins/{{ .Values.csiDriver.name }}/csi.sock
     # if you do not want to completely override the defaults use this
     extraArgs: []
     resources:
+    verbosityLevel: 5
 
   extraVolumes: []
   #  - name: foo

--- a/stable/snapshot-controller/values.yaml
+++ b/stable/snapshot-controller/values.yaml
@@ -19,10 +19,11 @@ controller:
     tag: ""
 
   args:
-    - "--v=5"
+    - "--v={{ .Values.controller.verbosityLevel }}"
     - "--leader-election=true"
     - "--enable-distributed-snapshotting"
   extraArgs: []
+  verbosityLevel: 5
 
 validatingWebhook:
   enabled: false


### PR DESCRIPTION
The binaries (like attacher, provisioner, etc.) run by this chart all have `--v=5` meaning basically _all_ logs generated by them are printed. This PR adds a new value `verbosityLevel` that can be used to set that level without having to mess with `args`. It keeps the default at 5, but gives you the option to lower it as needed in your scenario. I've been running a version of this chart with it set to `0` and noticed a good downtick in unnecessary (to me) logs.

![ScreenShot 2025-07-07 at 11 22 26](https://github.com/user-attachments/assets/b0aad9e3-92cc-40a9-ae28-07b110cf94ef)
