### PR TITLE
fix: absent kubelet plugins registry

### DIFF
--- a/stable/democratic-csi/Chart.yaml
+++ b/stable/democratic-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: csi storage for container orchestration systems
 name: democratic-csi
-version: 0.15.0
+version: 0.15.1

--- a/stable/democratic-csi/templates/node.yaml
+++ b/stable/democratic-csi/templates/node.yaml
@@ -279,7 +279,7 @@ spec:
       - name: registration-dir
         hostPath:
           path: {{ .Values.node.kubeletHostPath }}/plugins_registry
-          type: Directory
+          type: DirectoryOrCreate
       - name: kubelet-dir
         hostPath:
           path: {{ .Values.node.kubeletHostPath }}


### PR DESCRIPTION
- fix node `registration-dir` volume to `DirectoryOrCreate` for better compatibility when `/plugins_registry` directory is missing on kubelet hosts.
- bump `democratic-csi` chart version to from `0.15.0` to `0.15.1` 